### PR TITLE
Fix missing file warning during build

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5,7 +5,6 @@ bin/restore.pl
 bin/restore93.pl
 Build.PL
 lib/PostgresTools.pm
-lib/PostgresTools/.Date.pm.swp
 lib/PostgresTools/Database.pm
 lib/PostgresTools/Date.pm
 LICENSE


### PR DESCRIPTION
Ebuilds are complaining about missing file:

```
WARNING: the following files are missing in your kit:
        lib/PostgresTools/.Date.pm.swp
Please inform the author.
```
